### PR TITLE
Make init public

### DIFF
--- a/Sources/Snowplow/Tracker/CrossDeviceParameterConfiguration.swift
+++ b/Sources/Snowplow/Tracker/CrossDeviceParameterConfiguration.swift
@@ -26,7 +26,7 @@ import Foundation
     /// Optional identifier/information for cross-navigation
     @objc var reason: String?
     
-    @objc init(
+    @objc public init(
         sessionId: Bool = true,
         subjectUserId: Bool = false,
         sourceId: Bool = true,


### PR DESCRIPTION
Make sure `init` can be used on `CrossDeviceParameterConfiguration`